### PR TITLE
Add more envs to base

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -252,3 +252,17 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         git \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+# Add more cross compiling info
+ENV ARCH=arm \
+    CC=${CROSS_COMPILE}gcc \
+    CXX=${CROSS_COMPILE}g++ \
+    STRIP=${CROSS_COMPILE}strip \
+    AR=${CROSS_COMPILE}ar \
+    RANLIB=${CROSS_COMPILE}ranlib \
+    OBJDUMP=${CROSS_COMPILE}objdump \
+    OBJCOPY=${CROSS_COMPILE}objcopy \
+    GDB=${CROSS_COMPILE}gdb \
+    NM=${CROSS_COMPILE}objcopy \
+    AS=${CROSS_COMPILE}as \
+    TARGET_PREFIX=$CROSS_COMPILE

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -253,9 +253,8 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Add more cross compiling info
-ENV ARCH=arm \
-    CC=${CROSS_COMPILE}gcc \
+# Add more cross compling envs
+ENV CC=${CROSS_COMPILE}gcc \
     CXX=${CROSS_COMPILE}g++ \
     STRIP=${CROSS_COMPILE}strip \
     AR=${CROSS_COMPILE}ar \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,6 @@
 # Essential cross-compiling build tools for the reMarkable
+ARG NGCONFIG="arm-remarkable-linux-gnueabihf"
+ARG CHOST="arm-linux-gnueabihf"
 FROM debian:buster
 
 # Install common building tools
@@ -15,7 +17,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && rm -rf /var/lib/apt/lists/*
 
 # Build crosstool-ng 1.24.0 and use it to build the toolchain
-COPY crosstool-ng /arm-remarkable-linux-gnueabihf
+COPY crosstool-ng "/$NGCONFIG"
 RUN export DEBIAN_FRONTEND=noninteractive \
     # Install build dependencies
     && apt-get update -y \
@@ -36,18 +38,18 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && git clone https://github.com/crosstool-ng/crosstool-ng \
     && cd crosstool-ng \
     && git checkout b2151f1dba2b20c310adfe7198e461ec4469172b \
-    && mv /arm-remarkable-linux-gnueabihf samples \
+    && mv "/$NGCONFIG" samples \
     && ./bootstrap \
     && ./configure --enable-local \
     && make \
     # Build the toolchain and install it in the following folder
     && export CT_PREFIX="/opt/x-tools" \
-    && ./ct-ng arm-remarkable-linux-gnueabihf \
+    && ./ct-ng "$NGCONFIG" \
     && ./ct-ng build \
     && cd .. \
     # Clean up
     && rm -rf crosstool-ng \
-    && rm /opt/x-tools/arm-remarkable-linux-gnueabihf/build.log.bz2 \
+    && rm "/opt/x-tools/$NGCONFIG/build.log.bz2" \
     && apt-get autoremove -y \
         autoconf \
         bison \
@@ -63,16 +65,27 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Add cross-compiling tools to PATH and configurations for common build systems
+# Configure the environment for cross-compiling
 ENV ARCH=arm \
-    CHOST="arm-linux-gnueabihf" \
-    CROSS_COMPILE="arm-linux-gnueabihf-" \
-    PATH="$PATH:/opt/x-tools/arm-remarkable-linux-gnueabihf/bin" \
-    PKG_CONFIG_LIBDIR="/opt/x-tools/arm-remarkable-linux-gnueabihf/arm-remarkable-linux-gnueabihf/sysroot/usr/lib/pkgconfig" \
-    SYSROOT="/opt/x-tools/arm-remarkable-linux-gnueabihf/arm-remarkable-linux-gnueabihf/sysroot"
+    AR="$CHOST-ar" \
+    AS="$CHOST-as" \
+    CC="$CHOST-gcc" \
+    CHOST="$CHOST" \
+    CROSS_COMPILE="$CHOST-" \
+    CXX="$CHOST-g++" \
+    GDB="$CHOST-gdb" \
+    NM="$CHOST-objcopy" \
+    OBJCOPY="$CHOST-objcopy" \
+    OBJDUMP="$CHOST-objdump" \
+    PATH="$PATH:/opt/x-tools/$NGCONFIG/bin" \
+    PKG_CONFIG_LIBDIR="/opt/x-tools/$NGCONFIG/$NGCONFIG/sysroot/usr/lib/pkgconfig" \
+    RANLIB="$CHOST-ranlib" \
+    STRIP="$CHOST-strip" \
+    SYSROOT="/opt/x-tools/$NGCONFIG/$NGCONFIG/sysroot" \
+    TARGET_PREFIX="$CHOST"
 
-COPY meson/arm-linux-gnueabihf /usr/share/meson/cross/arm-linux-gnueabihf
-COPY cmake/arm-linux-gnueabihf.cmake /usr/share/cmake/arm-linux-gnueabihf.cmake
+COPY "meson/$CHOST" "/usr/share/meson/cross/$CHOST"
+COPY "cmake/$CHOST.cmake" "/usr/share/cmake/$CHOST.cmake"
 
 # Build libcap 2.25 targeting armhf
 RUN export DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
This adds a couple more envs to the base image. I added them last since I ran into linking problems when adding those where `CROSS_COMPILE` and others are (probably something got accidentally as arm).

I used oecore in looking up the envs to add. Those should be all the common envs.

<details>
<summary>(All the envs oecore sets when sourced)</summary>

```
SDKTARGETSYSROOT=/usr/local/oecore-x86_64/sysroots/cortexa9hf-neon-oe-linux-gnueabi
PKG_CONFIG_SYSROOT_DIR=/usr/local/oecore-x86_64/sysroots/cortexa9hf-neon-oe-linux-gnueabi
PKG_CONFIG_PATH=/usr/local/oecore-x86_64/sysroots/cortexa9hf-neon-oe-linux-gnueabi/usr/lib/pkgconfig:/usr/local/oecore-x86_64/sysroots/cortexa9hf-neon-oe-linux-gnueabi/usr/share/pkgconfig
CONFIG_SITE=/usr/local/oecore-x86_64/site-config-cortexa9hf-neon-oe-linux-gnueabi
OECORE_NATIVE_SYSROOT=/usr/local/oecore-x86_64/sysroots/x86_64-oesdk-linux
OECORE_TARGET_SYSROOT=/usr/local/oecore-x86_64/sysroots/cortexa9hf-neon-oe-linux-gnueabi
OECORE_ACLOCAL_OPTS=-I /usr/local/oecore-x86_64/sysroots/x86_64-oesdk-linux/usr/share/aclocal
CC=arm-oe-linux-gnueabi-gcc  -march=armv7-a -mfpu=neon -mfloat-abi=hard -mcpu=cortex-a9 --sysroot=/usr/local/oecore-x86_64/sysroots/cortexa9hf-neon-oe-linux-gnueabi
CXX=arm-oe-linux-gnueabi-g++  -march=armv7-a -mfpu=neon -mfloat-abi=hard -mcpu=cortex-a9 --sysroot=/usr/local/oecore-x86_64/sysroots/cortexa9hf-neon-oe-linux-gnueabi
CPP=arm-oe-linux-gnueabi-gcc -E  -march=armv7-a -mfpu=neon -mfloat-abi=hard -mcpu=cortex-a9 --sysroot=/usr/local/oecore-x86_64/sysroots/cortexa9hf-neon-oe-linux-gnueabi
AS=arm-oe-linux-gnueabi-as 
LD=arm-oe-linux-gnueabi-ld  --sysroot=/usr/local/oecore-x86_64/sysroots/cortexa9hf-neon-oe-linux-gnueabi
GDB=arm-oe-linux-gnueabi-gdb
STRIP=arm-oe-linux-gnueabi-strip
RANLIB=arm-oe-linux-gnueabi-ranlib
OBJCOPY=arm-oe-linux-gnueabi-objcopy
OBJDUMP=arm-oe-linux-gnueabi-objdump
AR=arm-oe-linux-gnueabi-ar
NM=arm-oe-linux-gnueabi-nm
M4=m4
TARGET_PREFIX=arm-oe-linux-gnueabi-
CONFIGURE_FLAGS=--target=arm-oe-linux-gnueabi --host=arm-oe-linux-gnueabi --build=x86_64-linux --with-libtool-sysroot=/usr/local/oecore-x86_64/sysroots/cortexa9hf-neon-oe-linux-gnueabi
CFLAGS= -O2 -pipe -g -feliminate-unused-debug-types 
CXXFLAGS= -O2 -pipe -g -feliminate-unused-debug-types 
LDFLAGS=-Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed
CPPFLAGS=
KCFLAGS=--sysroot=/usr/local/oecore-x86_64/sysroots/cortexa9hf-neon-oe-linux-gnueabi
OECORE_DISTRO_VERSION=1.1
OECORE_SDK_VERSION=nodistro.0
ARCH=arm
CROSS_COMPILE=arm-oe-linux-gnueabi-
OE_QMAKE_CFLAGS= -O2 -pipe -g -feliminate-unused-debug-types 
OE_QMAKE_CXXFLAGS= -O2 -pipe -g -feliminate-unused-debug-types 
OE_QMAKE_LDFLAGS=-Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed
OE_QMAKE_CC=arm-oe-linux-gnueabi-gcc  -march=armv7-a -mfpu=neon -mfloat-abi=hard -mcpu=cortex-a9 --sysroot=/usr/local/oecore-x86_64/sysroots/cortexa9hf-neon-oe-linux-gnueabi
OE_QMAKE_CXX=arm-oe-linux-gnueabi-g++  -march=armv7-a -mfpu=neon -mfloat-abi=hard -mcpu=cortex-a9 --sysroot=/usr/local/oecore-x86_64/sysroots/cortexa9hf-neon-oe-linux-gnueabi
OE_QMAKE_LINK=arm-oe-linux-gnueabi-g++  -march=armv7-a -mfpu=neon -mfloat-abi=hard -mcpu=cortex-a9 --sysroot=/usr/local/oecore-x86_64/sysroots/cortexa9hf-neon-oe-linux-gnueabi
OE_QMAKE_AR=arm-oe-linux-gnueabi-ar
OE_QMAKE_STRIP=arm-oe-linux-gnueabi-strip
QT_CONF_PATH=/usr/local/oecore-x86_64/sysroots/x86_64-oesdk-linux/usr/bin/qt.conf
OE_QMAKE_LIBDIR_QT=/usr/local/oecore-x86_64/sysroots/cortexa9hf-neon-oe-linux-gnueabi/usr/lib
OE_QMAKE_INCDIR_QT=/usr/local/oecore-x86_64/sysroots/cortexa9hf-neon-oe-linux-gnueabi/usr/include
OE_QMAKE_MOC=/usr/local/oecore-x86_64/sysroots/x86_64-oesdk-linux/usr/bin/moc
OE_QMAKE_UIC=/usr/local/oecore-x86_64/sysroots/x86_64-oesdk-linux/usr/bin/uic
OE_QMAKE_RCC=/usr/local/oecore-x86_64/sysroots/x86_64-oesdk-linux/usr/bin/rcc
OE_QMAKE_QDBUSCPP2XML=/usr/local/oecore-x86_64/sysroots/x86_64-oesdk-linux/usr/bin/qdbuscpp2xml
OE_QMAKE_QDBUSXML2CPP=/usr/local/oecore-x86_64/sysroots/x86_64-oesdk-linux/usr/bin/qdbusxml2cpp
OE_QMAKE_QT_CONFIG=/usr/local/oecore-x86_64/sysroots/cortexa9hf-neon-oe-linux-gnueabi/usr/lib/mkspecs/qconfig.pri
OE_QMAKE_PATH_HOST_BINS=/usr/local/oecore-x86_64/sysroots/x86_64-oesdk-linux/usr/bin
QMAKESPEC=/usr/local/oecore-x86_64/sysroots/cortexa9hf-neon-oe-linux-gnueabi/usr/lib/mkspecs/linux-oe-g++
```
</details>

We should also consider adding `$CFLAGS` and arguments to `$CC` and `$CXX` like oecore does, but I was not sure yet and wanted to prevent too many potentially breaking changes at once. I'll probably do a compile test  (`make repo -l` in toltec) with this images later or tomorrow.

**EDIT**: I already tested all the specified vars to be available in the container. I didn't add M4, as we don't have that one in the toolchain, yet.