### PR TITLE
Adds golang toolchain support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Name | Contents
 [qt](https://github.com/orgs/toltec-dev/packages/container/package/qt) | Adds Qt 5.11.3 to the host system root, including the closed-source libqsgepaper plugin. Includes the `qmake` build tool in the build system root.
 [rust](https://github.com/orgs/toltec-dev/packages/container/package/rust) | Adds Nightly Rust configured to use the ARMv7 cross-compiler to the build system root.
 [python](https://github.com/orgs/toltec-dev/packages/container/package/python) | Adds a Python 3.7.3 distribution to the build system root.
+[golang](https://github.com/orgs/toltec-dev/packages/container/package/golang) | Adds a Go 1.16.2 distribution to the build system root.
 
 ### Installing Opkg packages
 

--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -4,7 +4,7 @@ FROM $FROM
 
 # Install rustup
 RUN cd /root \
-    && curl --proto '=https' --tlsv1.2 -sSf https://golang.org/dl/go1.16.2.linux-amd64.tar.gz \
+    && curl --proto '=https' --tlsv1.2 -sSf https://dl.google.com/go/go1.16.2.linux-amd64.tar.gz \
     -o "go1.16.2.linux-amd64.tar.gz" \
     && tar -C /usr/local -xzf "go1.16.2.linux-amd64.tar.gz" \
     && mkdir -p ./go

--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -2,7 +2,7 @@
 ARG FROM
 FROM $FROM
 
-# Install rustup
+# Install golang
 RUN cd /root \
     && curl --proto '=https' --tlsv1.2 -sSf https://dl.google.com/go/go1.16.2.linux-amd64.tar.gz \
     -o "go1.16.2.linux-amd64.tar.gz" \

--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -1,0 +1,14 @@
+# Go distribution
+ARG FROM
+FROM $FROM
+
+# Install rustup
+RUN cd /root \
+    && curl --proto '=https' --tlsv1.2 -sSf https://golang.org/dl/go1.16.2.linux-amd64.tar.gz \
+    -o "go1.16.2.linux-amd64.tar.gz" \
+    && tar -C /usr/local -xzf "go1.16.2.linux-amd64.tar.gz" \
+    && mkdir -p ./go
+
+# Add go binaries to PATH
+ENV PATH="$PATH:/usr/local/go/bin"
+ENV GOPATH="/root/go"

--- a/scripts/build
+++ b/scripts/build
@@ -72,6 +72,10 @@ pushd "$imagesdir"/base
 docker-build toolchain base
 popd
 
+pushd "$imagesdir"/golang
+docker-build base golang
+popd
+
 pushd "$imagesdir"/python
 docker-build base python
 popd


### PR DESCRIPTION
Tested by running
`scripts/build .` and confirming that all docker images build ok, including new `golang` one. The error re no cached manifest is expected since this is new.

```
=> Building image 'ghcr.io/toltec-dev/golang:latest'
[+] Building 8.4s (8/8) FINISHED                                                                                                                                                                 
 => [internal] load build definition from Dockerfile                                                                                                                                        0.0s
 => => transferring dockerfile: 414B                                                                                                                                                        0.0s
 => [internal] load .dockerignore                                                                                                                                                           0.0s
 => => transferring context: 2B                                                                                                                                                             0.0s
 => [internal] load metadata for ghcr.io/toltec-dev/base:latest                                                                                                                             0.0s
 => ERROR importing cache manifest from ghcr.io/toltec-dev/golang:latest                                                                                                                    0.2s
 => CACHED [1/2] FROM ghcr.io/toltec-dev/base:latest                                                                                                                                        0.0s
 => [2/2] RUN cd /root     && curl --proto '=https' --tlsv1.2 -sSf https://dl.google.com/go/go1.16.2.linux-amd64.tar.gz     -o "go1.16.2.linux-amd64.tar.gz"     && tar -C /usr/local -xzf  5.2s
 => exporting to image                                                                                                                                                                      0.0s
 => => exporting layers                                                                                                                                                                     0.0s
 => => writing image sha256:86d6fffc8c88bf3134cbb9259694c4dd2ef9dee44c3900d5167b73c05b59e038                                                                                                0.0s
 => => naming to ghcr.io/toltec-dev/golang:latest                                                                                                                                           0.0s
 => exporting cache                                                                                                                                                                         0.0s
 => => preparing build cache for export                                                                                                                                                     0.0s
------
 > importing cache manifest from ghcr.io/toltec-dev/golang:latest:
------

```