### PR TITLE
Update golang to v1.20.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,18 +1,22 @@
 name: build
 on:
-    push:
-        branches:
-            - v1.x
-            - v2.x
-            - v3.x
+  push:
+    branches:
+      - v1.x
+      - v2.x
+      - v3.x
 jobs:
-    build:
-        name: Publish latest
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout the Git repository
-              uses: actions/checkout@v2
-            - name: Build and publish images
-              run: |
-                echo "${{ secrets.CR_PAT }}" | docker login ghcr.io -u matteodelabre --password-stdin
-                ./scripts/build -p .
+  build:
+    name: Publish latest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the Git repository
+        uses: actions/checkout@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: matteodelabre
+          password: ${{ secrets.CR_PAT }}
+      - name: Build and publish images
+        run: |
+          ./scripts/build -p .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
+          repository: ghcr.io
           username: matteodelabre
           password: ${{ secrets.CR_PAT }}
       - name: Build and publish images

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,6 @@
 name: pr
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - v1.x
       - v2.x
@@ -14,12 +14,6 @@ jobs:
     steps:
       - name: Checkout the Git repository
         uses: actions/checkout@v3
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          repository: ghcr.io
-          username: matteodelabre
-          password: ${{ secrets.CR_PAT }}
       - name: Build images
         run: |
           ./scripts/build .

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,18 +1,22 @@
 name: pr
 on:
-    pull_request:
-        branches:
-            - v1.x
-            - v2.x
-            - v3.x
+  pull_request:
+    branches:
+      - v1.x
+      - v2.x
+      - v3.x
 jobs:
-    build:
-        name: Publish latest
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout the Git repository
-              uses: actions/checkout@v2
-            - name: Build images
-              run: |
-                echo "${{ secrets.CR_PAT }}" | docker login ghcr.io -u matteodelabre --password-stdin
-                ./scripts/build .
+  build:
+    name: Publish latest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the Git repository
+        uses: actions/checkout@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: matteodelabre
+          password: ${{ secrets.CR_PAT }}
+      - name: Build images
+        run: |
+          ./scripts/build .

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,6 @@
 name: pr
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - v1.x
       - v2.x
@@ -9,12 +9,15 @@ jobs:
   build:
     name: Publish latest
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout the Git repository
         uses: actions/checkout@v3
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
+          repository: ghcr.io
           username: matteodelabre
           password: ${{ secrets.CR_PAT }}
       - name: Build images

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
+          repository: ghcr.io
           username: matteodelabre
           password: ${{ secrets.CR_PAT }}
       - name: Build and publish images

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,21 @@
 name: release
 on:
-    push:
-        tags:
-            - '*'
+  push:
+    tags:
+      - '*'
 jobs:
-    release:
-        name: Publish a release
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout the Git repository
-              uses: actions/checkout@v2
-            - name: Build and publish images
-              run: |
-                echo "${{ secrets.CR_PAT }}" | docker login ghcr.io -u matteodelabre --password-stdin
-                version="$(echo "${{ github.ref }}" | cut -d / -f 3)"
-                ./scripts/build -p . "$version"
+  release:
+    name: Publish a release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the Git repository
+        uses: actions/checkout@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: matteodelabre
+          password: ${{ secrets.CR_PAT }}
+      - name: Build and publish images
+        run: |
+          version="$(echo "${{ github.ref }}" | cut -d / -f 3)"
+          ./scripts/build -p . "$version"

--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -5,11 +5,11 @@ FROM $FROM
 # Install golang
 RUN cd /root \
     && curl --proto '=https' --tlsv1.2 -sSf \
-        https://dl.google.com/go/go1.17.1.linux-amd64.tar.gz \
-        -o go1.17.1.linux-amd64.tar.gz \
-    && tar -C /usr/local -xzf go1.17.1.linux-amd64.tar.gz \
+        https://dl.google.com/go/go1.20.7.linux-amd64.tar.gz \
+        -o go1.20.7.linux-amd64.tar.gz \
+    && tar -C /usr/local -xzf go1.20.7.linux-amd64.tar.gz \
     && mkdir go \
-    && rm go1.17.1.linux-amd64.tar.gz
+    && rm go1.20.7.linux-amd64.tar.gz
 
 # Add go binaries to PATH
 ENV PATH="$PATH:/usr/local/go/bin"


### PR DESCRIPTION
go only officially supports the two most recent minor versions: 1.20 and 1.21; 1.21 just released (1.20.0) so 1.20 will be supported for 6 more months, until 1.22 releases.

Go has had no breaking changes since the previous release used, 1.17 however it has added a new syntax for generics in 1.18.

Go does very well keeping code written in older versions working: https://tip.golang.org/doc/go1compat
