### PR TITLE
Add linux/arm64 platforms to image builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ jobs:
           registry: ghcr.io
           username: matteodelabre
           password: ${{ secrets.CR_PAT }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Build and publish images
         run: |
           ./scripts/build -p .

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout the Git repository
         uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Build images
         run: |
           ./scripts/build .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
           registry: ghcr.io
           username: matteodelabre
           password: ${{ secrets.CR_PAT }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Build and publish images
         run: |
           version="$(echo "${{ github.ref }}" | cut -d / -f 3)"

--- a/scripts/build
+++ b/scripts/build
@@ -45,18 +45,17 @@ fi
 imagesdir="$1"
 version="$2"
 
-# Enable BuildKit for better cache behavior
-# See <https://docs.docker.com/engine/reference/builder/#buildkit>
-export DOCKER_BUILDKIT=1
+docker buildx create --use
 
 docker-build() {
     from="$(image-name "$1" "$version")"
     target="$(image-name "$2" "$version")"
     status "Building image '$target'"
-    docker image build \
+    docker buildx build \
         --build-arg BUILDKIT_INLINE_CACHE=1 \
         --build-arg FROM="$from" \
         --cache-from "$(image-name "$2")" \
+        --platform linux/amd64,linux/arm64 \
         --tag "$target" .
 
     if [[ -n $publishflag ]]; then


### PR DESCRIPTION
This should allow the toolchain to be easily used on apple silicon macs (or any other arm64 device).

Closes #28